### PR TITLE
Add schibsted media to adopters list

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -42,6 +42,7 @@ Please maintain an alphabetical order in the following list -->
 - [Roboception](https://www.youtube.com/watch?v=JQnn5C4u6LY)
 - [RunX.dev](https://runx.dev/)
 - [Schibsted](https://schibsted.com/)
+- [Schibsted Media](https://schibstedmedia.com/)
 - [Spotify](https://www.spotify.com/)
 - [Stash](https://www.stash.com/)
 - [Stripe](https://www.youtube.com/watch?v=gRxdvrA9VAs)


### PR DESCRIPTION
Schibsted has split into two companies: 
1. Schibsted Media
2. Schibsted Marketplaces (which has the https://schibsted.com/). They will soon change their name to Vend. More info about that here: https://schibsted.com/news/schibsted-marketplaces-reveals/. 